### PR TITLE
Remove break statement in video leaf search

### DIFF
--- a/main.py
+++ b/main.py
@@ -815,7 +815,6 @@ class YuketangHeartbeat:
                                 }
                                 video_leafs.append(video_info)
                                 print(f"  找到视频: ID={video_info['id']} (实际leaf), 名称={video_info['name']}, 章节={chapter_name}")
-                                break
                     else:
                         # 如果没有leaf_list，这可能是一个简单的视频section
                         # 我们需要通过其他方式找到实际的video leaf ID


### PR DESCRIPTION
第818行错误地出现了一个`break`，使得同一节内第一个视频之后的视频无法被播放。这个pr修复了这个问题。